### PR TITLE
Set up auto-syncing of edge branch from upstream (with branch locked for everything else)

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -2,7 +2,7 @@
 # See: https://github.com/repository-settings/app
 # See: https://github.com/repository-settings/app/blob/master/docs/plugins/rulesets.md
 rulesets:
-  - name: edge-sync-only
+  - name: Only allow workflow to sync edge branch
     target: branch
     enforcement: active
     bypass_actors:

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,21 @@
+# This is for documentation purposes, and not actually used as config in code yet.
+# See: https://github.com/repository-settings/app
+# See: https://github.com/repository-settings/app/blob/master/docs/plugins/rulesets.md
+rulesets:
+  - name: edge-sync-only
+    target: branch
+    enforcement: active
+    bypass_actors:
+      # Only deploy key with write access can bypass, not any admin user.
+      - actor_id: null
+        actor_type: DeployKey
+
+    conditions:
+      ref_name:
+        include:
+          - "refs/heads/edge"
+        exclude: []
+    rules:
+      - type: update
+        parameters:
+          update_allows_fetch_and_merge: true

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -17,8 +17,9 @@ jobs:
         # See: https://github.com/ad-m/github-push-action#:~:text=push%20to%20a-,protected%20branch,-inside%20your%20repository
         # See: https://github.com/ad-m/github-push-action#:~:text=authenticate%20with%20GitHub%20Platform%20via%20Deploy%20Keys%20or%20in%20general%20SSH
         # TODO: Document branch ruleset.
-        ssh-key: ${{ secrets.EDGE_SYNCER_KEY_PRIV }}
-        persist-credentials: true
+#        ssh-key: ${{ secrets.EDGE_SYNCER_KEY_PRIV }}
+#        persist-credentials: true
+        token: ${{ secrets.PAT_TOKEN }}
         fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
         repository: compdemocracy/polis
         ref: edge
@@ -27,6 +28,7 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         # This approach allows us to bypass branch protection. (See above)
-        ssh: true
+        #ssh: true
+        github_token: ${{ secrets.PAT_TOKEN }}
         branch: edge
         repository: patcon/polis

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -1,0 +1,27 @@
+name: 'Merge to Development'
+on:
+  # Allow manual trigger from workflow page.
+  workflow_dispatch:
+
+  # Every day at 2am ET (6am UTC)
+  # See: https://crontab.guru/#0_6_*_*_*
+  schedule:
+    - cron:  '0 6 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+        fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
+        repository: compdemocracy/polis
+        ref: edge
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}
+        repository: patcon/polis
+        branch: edge

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -26,6 +26,6 @@ jobs:
       with:
         # This approach allows us to bypass branch protection.
         # See: https://github.com/ad-m/github-push-action#:~:text=push%20to%20a-,protected%20branch,-inside%20your%20repository
-        token: ${{ secrets.PAT_TOKEN }}
+        github_token: ${{ secrets.PAT_TOKEN }}
         branch: edge
         repository: patcon/polis

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -17,9 +17,8 @@ jobs:
         # See: https://github.com/ad-m/github-push-action#:~:text=push%20to%20a-,protected%20branch,-inside%20your%20repository
         # See: https://github.com/ad-m/github-push-action#:~:text=authenticate%20with%20GitHub%20Platform%20via%20Deploy%20Keys%20or%20in%20general%20SSH
         # TODO: Document branch ruleset.
-#        ssh-key: ${{ secrets.EDGE_SYNCER_KEY_PRIV }}
-#        persist-credentials: true
-        token: ${{ secrets.PAT_TOKEN }}
+        ssh-key: ${{ secrets.EDGE_SYNCER_KEY_PRIV }}
+        persist-credentials: true
         fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
         repository: compdemocracy/polis
         ref: edge
@@ -28,7 +27,6 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         # This approach allows us to bypass branch protection. (See above)
-        #ssh: true
-        github_token: ${{ secrets.PAT_TOKEN }}
+        ssh: true
         branch: edge
         repository: patcon/polis

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        # This approach allows us to bypass branch protection.
+        # See: https://github.com/ad-m/github-push-action#:~:text=push%20to%20a-,protected%20branch,-inside%20your%20repository
+        token: ${{ secrets.PAT_TOKEN }}
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
         fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
         repository: compdemocracy/polis
@@ -21,6 +24,8 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        # This approach allows us to bypass branch protection.
+        # See: https://github.com/ad-m/github-push-action#:~:text=push%20to%20a-,protected%20branch,-inside%20your%20repository
+        token: ${{ secrets.PAT_TOKEN }}
         branch: edge
         repository: patcon/polis

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -42,6 +42,7 @@ jobs:
         repository: compdemocracy/polis
         ref: edge
 
+    # See: https://github.com/ad-m/github-push-action
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -15,8 +15,10 @@ jobs:
       with:
         # This approach allows us to bypass branch protection.
         # See: https://github.com/ad-m/github-push-action#:~:text=push%20to%20a-,protected%20branch,-inside%20your%20repository
-        token: ${{ secrets.PAT_TOKEN }}
-        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+        # See: https://github.com/ad-m/github-push-action#:~:text=authenticate%20with%20GitHub%20Platform%20via%20Deploy%20Keys%20or%20in%20general%20SSH
+        # TODO: Document branch ruleset.
+        ssh-key: ${{ secrets.EDGE_SYNCER_KEY_PRIV }}
+        persist-credentials: true
         fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
         repository: compdemocracy/polis
         ref: edge
@@ -24,8 +26,7 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        # This approach allows us to bypass branch protection.
-        # See: https://github.com/ad-m/github-push-action#:~:text=push%20to%20a-,protected%20branch,-inside%20your%20repository
-        github_token: ${{ secrets.PAT_TOKEN }}
+        # This approach allows us to bypass branch protection. (See above)
+        ssh: true
         branch: edge
         repository: patcon/polis

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -1,3 +1,22 @@
+# This workflow has a few parts:
+#
+# 1. a passwordless SSH deploy key that was generated on a workstation via
+#
+#         ssh-keygen -t ed25519 -C "dummy@example.com" -f /tmp/id_ed25519
+#
+#   - private key as EDGE_SYNCER_KEY_PRIV env var
+#     - see: https://github.com/patcon/polis/settings/secrets/actions
+#   - public key as "edge-syncer"
+#     - see: https://github.com/patcon/polis/settings/keys
+# 2. this workflow file
+#   - does codebase checkout with EDGE_SYNCER_KEY_PRIV
+#   - ssh key is persisted
+#   - ssh key is used during push
+# 3. a branch protection ruleset than bans everyone from touching edge branch except the SSH deploy key.
+#   - Set up manually, but documented in code config here (not actually used).
+#   - TODO: Set up "Repository Settings app" to allow repo config via file.
+#   - See: .github/config.yml for details
+
 name: Sync edge branch from upstream
 on:
   # Allow manual trigger from workflow page.

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -5,9 +5,9 @@
 #         ssh-keygen -t ed25519 -C "dummy@example.com" -f /tmp/id_ed25519
 #
 #   - private key as EDGE_SYNCER_KEY_PRIV env var
-#     - see: https://github.com/patcon/polis/settings/secrets/actions
+#     - see: https://github.com/CivicTechTO/polis/settings/secrets/actions
 #   - public key as "edge-syncer"
-#     - see: https://github.com/patcon/polis/settings/keys
+#     - see: https://github.com/CivicTechTO/polis/settings/keys
 # 2. this workflow file
 #   - does codebase checkout with EDGE_SYNCER_KEY_PRIV
 #   - ssh key is persisted
@@ -48,4 +48,3 @@ jobs:
         # This approach allows us to bypass branch protection. (See above)
         ssh: true
         branch: edge
-        repository: patcon/polis

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -1,4 +1,4 @@
-name: 'Merge to Development'
+name: Sync edge branch from upstream
 on:
   # Allow manual trigger from workflow page.
   workflow_dispatch:
@@ -22,6 +22,5 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ github.ref }}
-        repository: patcon/polis
         branch: edge
+        repository: patcon/polis


### PR DESCRIPTION
Resolves #53 

This adds a new workflow to run regularly and pull commit from upstream `edge` and push them to our `edge`, so it stays up-to-date. It also documents some associated settings changes in repo.

It is currently set up to run once/day at 2am ET, and can be manually triggered from it's workflow page (see screenshot below).

The hard part was making it so that a workflow could push to a protected branch, but no regular users can without changing settings, even ones who are admin on the repo (who might easily do so by accident).

Starting review with the workflow file will be most helpful, as it explain context on the rest :)

Of note:
- admins can't push any new refs to branch (ONLY the workflow can push, via its repo deploy key)
- making any changes to `edge` will require adding a bypass to the branch protection rule (for admin users)

## Todos

- [x] write the workflow
- [x] documented repo ruleset config in code: `.github/config.yml`
- [x] test the workflow (see [`patcon/polis`](https://github.com/patcon/polis/actions/workflows/sync-from-upstream.yml) repo)
  - [x] that admin can't push from workstation via ssh key
  - [x] that admin personal access token can't push
  - [x] that workflow github_token can't push
  - [x] that deploy key in workflow CAN push
- will do if/when approved
  - [ ] remove classic branch protection rule
  - [ ] create new branch protection _ruleset_ (doc'd in code)
  - [ ] generated passworld SSH key with write access to repo
  - [ ] add repo secret `EDGE_SYNCER_KEY_PRIV`
    - see: https://github.com/CivicTechTO/polis/settings/secrets/actions
  - [ ] add public SSH deploy key to repo `edge-syncer`
    - see: https://github.com/CivicTechTO/polis/settings/keys
  - [x] update final docs mentions from patcon/polis to CivicTechTO/polis repo

## Screenshot of manual trigger

<img width="1096" alt="Screenshot 2024-10-22 at 4 38 23 PM" src="https://github.com/user-attachments/assets/64fd1ac0-8a0c-468a-bb32-3f9692375ec8">