### PR TITLE
Removed @Radium decorator in favour of manually wrapped class compone…

### DIFF
--- a/client-admin/src/components/conversation-admin/seed-tweet.js
+++ b/client-admin/src/components/conversation-admin/seed-tweet.js
@@ -22,7 +22,6 @@ const styles = {
 }
 
 @connect((state) => state.seed_comments_tweet)
-@Radium
 class ModerateCommentsSeed extends React.Component {
   constructor(props) {
     super(props)
@@ -134,6 +133,7 @@ ModerateCommentsSeed.propTypes = {
   })
 }
 
+ModerateCommentsSeed = Radium(ModerateCommentsSeed)
 export default ModerateCommentsSeed
 
 /*

--- a/client-admin/src/components/conversation-admin/seed-tweet.js
+++ b/client-admin/src/components/conversation-admin/seed-tweet.js
@@ -22,7 +22,7 @@ const styles = {
 }
 
 @connect((state) => state.seed_comments_tweet)
-class ModerateCommentsSeed extends React.Component {
+class ModerateCommentsSeedClass extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -122,7 +122,7 @@ class ModerateCommentsSeed extends React.Component {
   }
 }
 
-ModerateCommentsSeed.propTypes = {
+ModerateCommentsSeedClass.propTypes = {
   dispatch: PropTypes.func,
   error: PropTypes.string,
   success: PropTypes.any,
@@ -133,7 +133,7 @@ ModerateCommentsSeed.propTypes = {
   })
 }
 
-ModerateCommentsSeed = Radium(ModerateCommentsSeed)
+const ModerateCommentsSeed = Radium(ModerateCommentsSeedClass)
 export default ModerateCommentsSeed
 
 /*

--- a/client-report/src/COMPONENT_TEMPLATE.js
+++ b/client-report/src/COMPONENT_TEMPLATE.js
@@ -12,7 +12,6 @@ import PropTypes from "prop-types";
 // @connect(state => {
 //   return state.FOO;
 // })
-@Radium
 class ComponentName extends React.Component {
   constructor(props) {
     super(props);
@@ -52,6 +51,7 @@ class ComponentName extends React.Component {
   }
 }
 
+ComponentName = Radium(ComponentName);
 export default ComponentName;
 
 /*

--- a/client-report/src/components/comment.js
+++ b/client-report/src/components/comment.js
@@ -8,7 +8,6 @@ import Flex from "./flex";
 import * as globals from "./globals";
 import BarChart from "./barChart";
 
-@Radium
 class Comment extends React.Component {
   static propTypes = {
     dispatch: PropTypes.func,
@@ -74,6 +73,7 @@ class Comment extends React.Component {
     }
   }
 
+  Comment = Radium(Comment);
   export default Comment;
 
   // <p>{this.props.comment.demographics.gender}</p>


### PR DESCRIPTION
Removed `@Radium` decorator in favour of manually wrapped class components.

This easily side-steps issue of custom decorator not working in Storybook.