### PR TITLE
Add thead in conversation tabs

### DIFF
--- a/client-participation/js/templates/conversationTabs.handlebars
+++ b/client-participation/js/templates/conversationTabs.handlebars
@@ -8,6 +8,13 @@
   >
 
  <table>
+    <thead>
+      <tr>
+        <th>Conversation Navigation</th>
+        <th>User Menu</th>
+      </tr>
+    </thead>
+    <tbody>
   <tr>
   <td style="width:100%">
   <ul class="nav nav-tabs tab-conv"
@@ -175,6 +182,8 @@
 {{/if}} {{! showLogout}}
 
 </td>
+      </tr>
+    </tbody>
 </table>
 
 </div>


### PR DESCRIPTION
Fix https://github.com/CivicTechTO/polis/issues/81

Add `thead` and `tbody`

Note. this UI is actually not in accessibility tree for [its grandparent has `display: none` style](https://github.com/YumiChen/polis/blob/c985ea14c523e147bf50b1331c2e8bf9e34d3bab/client-participation/js/templates/conversationTabs.handlebars#L7). We can see if we want to review whether to include these types of issues in the board