### PR TITLE
Fix in-page link without target

### DIFF
--- a/client-participation/js/templates/conversationTabs.handlebars
+++ b/client-participation/js/templates/conversationTabs.handlebars
@@ -147,10 +147,10 @@
 
 {{!-- {{#ifAuthenticated}} --}}
   {{#unless hasTwitter}}
-    <li id="twitterConnectBtn" role="menuitem"><div style="display: inline-block; width: 20px"><i class="fa fa-twitter"></i></div>Connect Twitter</li>
+    <li role="presentation"><button id="twitterConnectBtn" role="menuitem"><div style="display: inline-block; width: 20px"><i class="fa fa-twitter"></i></div>Connect Twitter</button></li>
   {{/unless}}
   {{#unless hasFacebook}}
-    <li id="fbConnectBtn" role="menuitem"><div style="display: inline-block; width: 20px"><i class="fa fa-facebook"></i></div>Connect Facebook</li>
+    <li role="presentation"><button id="fbConnectBtn" role="menuitem"><div style="display: inline-block; width: 20px"><i class="fa fa-facebook"></i></div>Connect Facebook</button></li>
   {{/unless}}
     {{!-- <li role="presentation"><a role="menuitem" href="#"><div style="display: inline-block; width: 20px"><img src="https://pol.is/polis-favicon_favicon.png" height="16px" id="opinion_groups_logo"/></div> Polis</a></li> --}}
 

--- a/client-participation/js/templates/conversationTabs.handlebars
+++ b/client-participation/js/templates/conversationTabs.handlebars
@@ -147,10 +147,10 @@
 
 {{!-- {{#ifAuthenticated}} --}}
   {{#unless hasTwitter}}
-    <li role="presentation"><a id="twitterConnectBtn" role="menuitem" href="#"><div style="display: inline-block; width: 20px"><i class="fa fa-twitter"></i></div>Connect Twitter</a></li>
+    <li id="twitterConnectBtn" role="menuitem"><div style="display: inline-block; width: 20px"><i class="fa fa-twitter"></i></div>Connect Twitter</li>
   {{/unless}}
   {{#unless hasFacebook}}
-    <li role="presentation"><a id="fbConnectBtn" role="menuitem" href="#"><div style="display: inline-block; width: 20px"><i class="fa fa-facebook"></i></div>Connect Facebook</a></li>
+    <li id="fbConnectBtn" role="menuitem"><div style="display: inline-block; width: 20px"><i class="fa fa-facebook"></i></div>Connect Facebook</li>
   {{/unless}}
     {{!-- <li role="presentation"><a role="menuitem" href="#"><div style="display: inline-block; width: 20px"><img src="https://pol.is/polis-favicon_favicon.png" height="16px" id="opinion_groups_logo"/></div> Polis</a></li> --}}
 


### PR DESCRIPTION
Fix https://github.com/CivicTechTO/polis/issues/79

For `twitterConnectBtn` and `fbConnectBtn` are not for page navigation( there are event listeners are bound to them instead), remove `a` tags and move `menuitem` role item to list items instead

Note. this UI is actually not in accessibility tree for [its grandparent has `display: none` style](https://github.com/YumiChen/polis/blob/c985ea14c523e147bf50b1331c2e8bf9e34d3bab/client-participation/js/templates/conversationTabs.handlebars#L7). We can see if we want to review whether to include these types of issues in the board