### PR TITLE
Add aria-labels to logo links in report page

### DIFF
--- a/client-report/src/components/framework/logoLargeShort.js
+++ b/client-report/src/components/framework/logoLargeShort.js
@@ -14,7 +14,7 @@ class PolisLogo extends React.Component {
   }
   render() {
     return (
-        <a style={this.styles().link} href="http://pol.is">
+        <a style={this.styles().link} href="http://pol.is" aria-label="Go to home page">
         <svg width="87px" height="100px" viewBox="0 0 87 100" >
             <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
                 <g id="100x100-transparent">

--- a/client-report/src/components/framework/logoSmallLong.js
+++ b/client-report/src/components/framework/logoSmallLong.js
@@ -12,6 +12,7 @@ class PolisLogo extends React.Component {
           padding: "8px 0px 4px 10px",
         }}
         href="http://pol.is"
+        aria-label="Go to home page"
       >
         <svg
           width="120px"


### PR DESCRIPTION
Fix https://github.com/CivicTechTO/polis/issues/73
Add aria-label `Go to home page` to the logo links in report page