### PR TITLE
Move participation page closed badge out of h1 heading

### DIFF
--- a/client-participation/js/templates/participation.handlebars
+++ b/client-participation/js/templates/participation.handlebars
@@ -171,25 +171,26 @@
       <h1
         class="HeadingA"
         style="
-         margin-bottom: 10px;
+        margin-bottom: 10px;
+        display: inline-block;
         "
         dir="auto">
         {{topic}}
-        {{#unless is_active}}
+      </h1>
+      {{#unless is_active}}
         <span class="no_you_vote" style="
-         color: white;
-         background-color: rgb(231, 76, 60);
-         /* font-size: 0.7em; */
-         /* padding: .2em; */
-         font-size: 20px;
-         padding: 0px 10px;
-         border-radius: 3px;
-         position: relative;
-         top: -5px;
-         left: 6px;
+        color: white;
+        background-color: rgb(231, 76, 60);
+        /* font-size: 0.7em; */
+        /* padding: .2em; */
+        font-size: 20px;
+        padding: 0px 10px;
+        border-radius: 3px;
+        position: relative;
+        top: -5px;
+        left: 6px;
         ">closed</span>
       {{/unless}}
-      </h1>
     {{/ifDefined}}
     {{/unless}}
 

--- a/e2e/cypress/e2e/client-admin/conversation.cy.js
+++ b/e2e/cypress/e2e/client-admin/conversation.cy.js
@@ -87,7 +87,8 @@ describe('Conversation: Configure', function () {
       cy.wait('@participationInit')
 
       cy.get('[data-view-name="participationView"]').should('be.visible')
-      cy.get('h1').contains('Test topic closed').should('be.visible')
+      cy.get('.POLIS_HEADLINE h1').contains('Test topic').should('be.visible')
+      cy.get('.POLIS_HEADLINE .no_you_vote').contains('closed').should('be.visible')
     })
   })
 })


### PR DESCRIPTION
Fix https://github.com/CivicTechTO/polis/issues/138
- Move closed badge out of `h1` to make it be announced in a separate sentence from the `h1` heading announcement
- Add `display: inline-block` style to `h1` to have `h1` and closed badge displayed in the same row